### PR TITLE
Allow running ssh as a different user

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ Environment Variables
     `/etc/nbd-server/config`). Defaults to `ragnar`.
   - `RAGNAR_KEYFILE`: Path to LUKS keyfile. Defaults to
     `/etc/luks/${RAGNAR_NBDEXPORT}.key`
+  - `RAGNAR_SSH_USER`: The remote SSH user to login as. Defaults
+    to the current user.
 
 Usage
 -----

--- a/ragnar.sh
+++ b/ragnar.sh
@@ -14,6 +14,7 @@ SERVER=${RAGNAR_SERVER:-localhost}
 NBDEXPORT=${RAGNAR_NBDEXPORT:-ragnar}
 KEYFILE=${RAGNAR_KEYFILE:-/etc/luks/${NBDEXPORT}.key}
 HEADER=${RAGNAR_HEADER:-/etc/luks/${NBDEXPORT}.header}
+SSH_USER=${RAGNAR_SSH_USER:-$(whoami)}
 
 TMP=$(tmpdirp "${SERVER}-${NBDEXPORT}")
 mkdir -p ${TMP}
@@ -23,7 +24,7 @@ ssh_is_open() {
 }
 
 open_ssh() {
-  ssh -fNn -MS "${TMP}/ssh" -L 10809:127.0.0.1:10809 ${SERVER}
+  ssh -fNn -MS "${TMP}/ssh" -L 10809:127.0.0.1:10809 ${SSH_USER}@${SERVER}
 }
 
 close_ssh() {


### PR DESCRIPTION
Often, ssh as root is disabled for security reasons.  In such situations in which one would want a passwordless unprivileged SSH tunnel while running `ragnar` as su, for unattended passwordless backups for example, it would be helpful to handle a`RAGNAR_SSH_USER` variable.  Defaulting to $(whoami) should avoid dependence on the existence or correctness of `$USER`.